### PR TITLE
Updated loss.py and metrics.py to allow serialisation (added test scr…

### DIFF
--- a/README.md
+++ b/README.md
@@ -47,10 +47,12 @@ This is a quick example to show a basic model implementation. With actual data o
 
 ```python
 import coral_ordinal as coral
+NUM_CLASSES = 5
 model = tf.keras.Sequential()
 model.add(tf.keras.layers.Dense(32, activation = "relu"))
-model.add(coral.CoralOrdinal(num_classes = 5)) # Ordinal variable has 5 labels, 0 through 4.
-model.compile(loss = coral.OrdinalCrossEntropy(), metrics = [coral.MeanAbsoluteErrorLabels])
+model.add(coral.CoralOrdinal(num_classes = NUM_CLASSES)) # Ordinal variable has 5 labels, 0 through 4.
+model.compile(loss = coral.OrdinalCrossEntropy(num_classes = NUM_CLASSES),
+              metrics = [coral.MeanAbsoluteErrorLabels()])
 ```
 
 [See this colab notebook](https://colab.research.google.com/drive/1AQl4XeqRRhd7l30bmgLVObKt5RFPHttn) for extended examples of ordinal regression with MNIST (multilayer perceptron) and Amazon reviews (universal sentence encoder).

--- a/coral_ordinal/loss.py
+++ b/coral_ordinal/loss.py
@@ -6,33 +6,26 @@ import numpy as np
 class OrdinalCrossEntropy(tf.keras.losses.Loss):
   
   def __init__(self,
-               num_classes = None,
-               importance = None,
+               num_classes,
+               importance_weights = None,
                from_type = "ordinal_logits",
-               name = "ordinal_crossent", **kwargs):
+               name = "ordinal_crossent",
+               reduction = tf.keras.losses.Reduction.NONE):
     """ Cross-entropy loss designed for ordinal outcomes.
     
     Args:
-      num_classes: (Optional) how many ranks (aka labels or values) are in the ordinal variable.
-        If not provided it will be automatically determined by on the prediction data structure.
-      importance: (Optional) importance weights for each binary classification task.
+      num_classes: number of ranks (aka labels or values) in the ordinal variable.
+      importance_weights: (Optional) importance weights for each binary classification task.
       from_type: one of "ordinal_logits" (default), "logits", or "probs".
         Ordinal logits are the output of a CoralOrdinal() layer with no activation.
         (Not yet implemented) Logits are the output of a dense layer with no activation.
         (Not yet implemented) Probs are the probability outputs of a softmax or ordinal_softmax layer.
     """
-    super(OrdinalCrossEntropy, self).__init__(name = name, **kwargs)
+    super().__init__(name = name, reduction = reduction)
     
     self.num_classes = num_classes
-      
-    #self.importance_weights = importance
-    if importance is None:
-      self.importance_weights = tf.ones(self.num_classes - 1, dtype = tf.float32)
-    else:
-      self.importance_weights = tf.cast(importance, dtype = tf.float32)
-      
+    self.importance_weights = importance_weights
     self.from_type = from_type
-
 
   # TODO: pre-compute so that this can be much faster on GPU.
   def label_to_levels(self, label):
@@ -59,25 +52,17 @@ class OrdinalCrossEntropy(tf.keras.losses.Loss):
     y_pred = tf.convert_to_tensor(y_pred)
     y_true = tf.cast(y_true, y_pred.dtype)
     
-    if self.num_classes is None:
-      # Determine number of classes based on prediction shape.
-      if self.from_type == "ordinal_logits":
-        # Number of classes = number of columns + 1
-        self.num_classes = y_pred.shape[1] + 1
-      else:
-        self.num_classes = y_pred.shape[1]
-
     # Convert each true label to a vector of ordinal level indicators.
     # TODO: do this outside of the model, so that it's faster?
     tf_levels = tf.map_fn(self.label_to_levels, y_true)
-    
-    #if self.importance_weights is None:
-      #self.importance_weights = np.ones(self.num_classes - 1, dtype = np.float32)
-      #self.importance_weights = tf.ones(self.num_classes - 1, dtype = np.float32)
+
+    if self.importance_weights is None:
+      importance_weights = tf.ones(self.num_classes - 1, dtype = tf.float32)
+    else:
+      importance_weights = tf.cast(self.importance_weights, dtype = tf.float32)
     
     if self.from_type == "ordinal_logits":
-      #return ordinal_loss(y_pred, tf_levels, self.importance_weights)
-      return ordinal_loss(y_pred, tf_levels, self.importance_weights)
+      return ordinal_loss(y_pred, tf_levels, importance_weights)
     elif self.from_type == "probs":
       raise Exception("not yet implemented")
     elif self.from_type == "logits":
@@ -85,6 +70,15 @@ class OrdinalCrossEntropy(tf.keras.losses.Loss):
     else:
       raise Exception("Unknown from_type value " + self.from_type +
                       " in OrdinalCrossEntropy()")
+
+  def get_config(self):
+    config = {
+        "num_classes": self.num_classes,
+        "importance_weights": self.importance_weights,
+        "from_type": self.from_type,
+    }
+    base_config = super().get_config()
+    return {**base_config, **config}
     
 #def ordinal_loss(logits, levels, importance):
 def ordinal_loss(logits, levels, importance):

--- a/coral_ordinal/metrics.py
+++ b/coral_ordinal/metrics.py
@@ -1,28 +1,63 @@
 import tensorflow as tf
-
-# TODO: this seems to be broken, compared to the Colab version.
-def MeanAbsoluteErrorLabels(y_true, y_pred):
-  # Assume that y_pred is cumulative logits from our CoralOrdinal layer.
-  
-  # Predict the label as in Cao et al. - using cumulative probabilities
-  #cum_probs = tf.map_fn(tf.math.sigmoid, y_pred)
-  
-  # Calculate the labels using the style of Cao et al.
-  # above_thresh = tf.map_fn(lambda x: tf.cast(x > 0.5, tf.float32), cum_probs)
-  
-  # Skip sigmoid and just operate on logit scale, since logit > 0 is
-  # equivalent to prob > 0.5.
-  above_thresh = tf.map_fn(lambda x: tf.cast(x > 0., tf.float32), y_pred)
-  
-  # Sum across columns so that we estimate how many cumulative thresholds are passed.
-  labels_v2 = tf.reduce_sum(above_thresh, axis = 1)
-  
-  # This can convert to an integer, which will mess with the calculations.
-  # labels_v2 = tf.cast(labels_v2, y_true.dtype)
-  
-  return tf.reduce_mean(tf.abs(y_true - labels_v2), axis = -1)
+from tensorflow.keras import backend as K
 
 
+class MeanAbsoluteErrorLabels(tf.keras.metrics.Metric):
+  """Computes mean absolute error for ordinal labels."""
+
+  def __init__(self, name="mean_absolute_error_labels", **kwargs):
+    """Creates a `MeanAbsoluteErrorLabels` instance."""
+    super(MeanAbsoluteErrorLabels, self).__init__(name=name, **kwargs)
+    self.maes = self.add_weight(name='maes', initializer='zeros')
+    self.count = self.add_weight(name='count', initializer='zeros')
+
+  def update_state(self, y_true, y_pred, sample_weight=None):
+    """Computes mean absolute error for ordinal labels.
+
+    Args:
+      y_true: Cumulatiuve logits from CoralOrdinal layer.
+      y_pred: Labels.
+      sample_weight (optional): Not implemented.
+    """
+
+    if sample_weight:
+      raise NotImplementedError
+
+    # Predict the label as in Cao et al. - using cumulative probabilities
+    #cum_probs = tf.map_fn(tf.math.sigmoid, y_pred)
+
+    # Calculate the labels using the style of Cao et al.
+    # above_thresh = tf.map_fn(lambda x: tf.cast(x > 0.5, tf.float32), cum_probs)
+
+    # Skip sigmoid and just operate on logit scale, since logit > 0 is
+    # equivalent to prob > 0.5.
+    above_thresh = tf.map_fn(lambda x: tf.cast(x > 0., tf.float32), y_pred)
+
+    # Sum across columns to estimate how many cumulative thresholds are passed.
+    labels_v2 = tf.reduce_sum(above_thresh, axis = 1)
+
+    y_true = tf.cast(y_true, y_pred.dtype)
+
+    # remove all dimensions of size 1 (e.g., from [[1], [2]], to [1, 2])
+    y_true = tf.squeeze(y_true)
+
+    self.maes.assign_add(tf.reduce_mean(tf.abs(y_true - labels_v2)))
+    self.count.assign_add(tf.constant(1.))
+
+  def result(self):
+    return tf.math.divide_no_nan(self.maes, self.count)
+
+  def reset_states(self):
+    """Resets all of the metric state variables at the start of each epoch."""
+    K.batch_set_value([(v, 0) for v in self.variables])
+
+  def get_config(self):
+    """Returns the serializable config of the metric."""
+    config = {}
+    base_config = super().get_config()
+    return {**base_config, **config}
+
+"""
 # WIP
 def MeanAbsoluteErrorLabels_v2(y_true, y_pred):
   # There will be num_classes - 1 cumulative logits as columns of the tensor.
@@ -31,3 +66,4 @@ def MeanAbsoluteErrorLabels_v2(y_true, y_pred):
   probs = logits_to_probs(y_pred, num_classes)
 
 # RootMeanSquaredErrorLabels
+"""

--- a/coral_ordinal/tests/metrics_test.py
+++ b/coral_ordinal/tests/metrics_test.py
@@ -1,0 +1,66 @@
+"""Tests for coral metric function."""
+import numpy as np
+import tensorflow as tf
+
+from coral_ordinal.metrics import MeanAbsoluteErrorLabels
+
+
+def test_config():
+    mael_obj = MeanAbsoluteErrorLabels()
+    assert mael_obj.name == "mean_absolute_error_labels"
+    assert mael_obj.dtype == tf.float32
+
+
+def get_data():
+    actuals = [[[7], [2], [1]],
+               [0, 0, 0],
+               [0, 0, 0]]
+    preds = [[[10.9, 6.3, 4.7, 3.4, 2.5, 1.8, 0.8, -0.4, -2.2], 
+              [5.9, 1.3, -0.2, -1.4, -2.3, -3.1, -4.1, -5.3, -7.1], 
+              [2.9, -1.6, -3.2, -4.5, -5.4, -6.1, -7.1, -8.4, -10.2]],
+             [[10.9, 6.3, 4.7, 3.4, 2.5, 1.8, 0.8, -0.4, -2.2], 
+              [5.9, 1.3, -0.2, -1.4, -2.3, -3.1, -4.1, -5.3, -7.1], 
+              [2.9, -1.6, -3.2, -4.5, -5.4, -6.1, -7.1, -8.4, -10.2]],
+             [[-1., -2., -3., -4., -5., -6., -7., -8., -9], \
+              [-1., -2., -3., -4., -5., -6., -7., -8., -9], \
+              [-1., -2., -3., -4., -5., -6., -7., -8., -9]]]
+    return actuals, preds
+
+
+def test_mae_labels_score():
+    actuals, preds = get_data()
+
+    mael_obj1 = MeanAbsoluteErrorLabels()
+    mael_obj1.update_state(
+        tf.constant(actuals[0], dtype=tf.int32),
+        tf.constant(preds[0], dtype=tf.float32))
+    # [7, 2, 1] - [7, 2, 1] = 0
+    np.testing.assert_allclose(0., mael_obj1.result())
+
+    mael_obj2 = MeanAbsoluteErrorLabels()
+    mael_obj2.update_state(
+        tf.constant(actuals[1], dtype=tf.int32),
+        tf.constant(preds[1], dtype=tf.float32))
+    # [7, 2, 1] - [0, 0, 0] = (7 + 2 + 1) / 3 = 3.3333333333
+    np.testing.assert_allclose(3.3333333333, mael_obj2.result())
+
+    mael_obj2 = MeanAbsoluteErrorLabels()
+    mael_obj2.update_state(
+        tf.constant(actuals[2], dtype=tf.int32),
+        tf.constant(preds[2], dtype=tf.float32))
+    # [0, 0, 0] - [0, 0, 0] = 0
+    np.testing.assert_allclose(0., mael_obj2.result())
+
+
+def test_mae_labels_running_score():
+    mael_obj = MeanAbsoluteErrorLabels()
+    actuals, preds = get_data()
+    for a, p in zip(actuals, preds):
+        mael_obj.update_state(
+            tf.constant(a, dtype=tf.int32),
+            tf.constant(p, dtype=tf.float32))
+    np.testing.assert_allclose(1.1111111111, mael_obj.result())
+
+    mael_obj.reset_states()
+    np.testing.assert_allclose(0., mael_obj.result())
+

--- a/coral_ordinal/tests/metrics_test.py
+++ b/coral_ordinal/tests/metrics_test.py
@@ -44,12 +44,12 @@ def test_mae_labels_score():
     # [7, 2, 1] - [0, 0, 0] = (7 + 2 + 1) / 3 = 3.3333333333
     np.testing.assert_allclose(3.3333333333, mael_obj2.result())
 
-    mael_obj2 = MeanAbsoluteErrorLabels()
-    mael_obj2.update_state(
+    mael_obj3 = MeanAbsoluteErrorLabels()
+    mael_obj3.update_state(
         tf.constant(actuals[2], dtype=tf.int32),
         tf.constant(preds[2], dtype=tf.float32))
     # [0, 0, 0] - [0, 0, 0] = 0
-    np.testing.assert_allclose(0., mael_obj2.result())
+    np.testing.assert_allclose(0., mael_obj3.result())
 
 
 def test_mae_labels_running_score():
@@ -59,6 +59,7 @@ def test_mae_labels_running_score():
         mael_obj.update_state(
             tf.constant(a, dtype=tf.int32),
             tf.constant(p, dtype=tf.float32))
+    # (0 + 3.3333333333 + 0) / 3 = 1.1111111111
     np.testing.assert_allclose(1.1111111111, mael_obj.result())
 
     mael_obj.reset_states()


### PR DESCRIPTION
Hello -- Serialization and deserialization were not working so this PR intends to fix that. The key things that have changed are:

1. Variables in `OrdinalCrossEntropy()` have changed to allow for serialization (specifically `num_classes` is no longer optional and `importance_weights` is a dtype that can be serialized).
2. The metric now subclasses from tf.keras to allow for serialization by implementing `get_config()`.
3. Fixed incorrect calculation of MAE for labels by using `tf.squeeze()` to ensure same rank tensors are passed to subtraction. Note: `axis=-1` was not needed in `tf.reduce_mean()` on L44 of metrics.py.
4. Added a test class to help with the above. I've also tested with my own model and the extended examples in colab linked to from the `README.md`.

What are your thoughts?