### PR TITLE
Vectorize ops (remove map_fn() calls) for up to 1000x speedup in loss/metric/softmax calculations

### DIFF
--- a/coral_ordinal/activations.py
+++ b/coral_ordinal/activations.py
@@ -14,7 +14,7 @@ def ordinal_softmax(x, axis=-1):
     num_classes = x.shape[1] + 1
 
     # Convert the ordinal logits into cumulative probabilities.
-    cum_probs = tf.map_fn(tf.math.sigmoid, x)
+    cum_probs = tf.math.sigmoid(x)
 
     # Create a list of tensors.
     probs = []

--- a/coral_ordinal/loss.py
+++ b/coral_ordinal/loss.py
@@ -29,7 +29,7 @@ def _ordinal_loss_no_reduction(
 
 
 # The outer function is a constructor to create a loss function using a certain number of classes.
-# @tf.keras.utils.register_keras_serializable(package="coral_ordinal")
+@tf.keras.utils.register_keras_serializable(package="coral_ordinal")
 class OrdinalCrossEntropy(tf.keras.losses.Loss):
     def __init__(
         self,

--- a/coral_ordinal/loss.py
+++ b/coral_ordinal/loss.py
@@ -5,20 +5,12 @@ import tensorflow as tf
 import numpy as np
 
 
-def _label_to_levels(label: tf.Tensor, num_classes: int):
+def _label_to_levels(labels: tf.Tensor, num_classes: int) -> tf.Tensor:
     # Original code that we are trying to replicate:
     # levels = [1] * label + [0] * (self.num_classes - 1 - label)
-    label_vec = tf.repeat(1, tf.cast(tf.squeeze(label), tf.int32))
-
-    # This line requires that label values begin at 0. If they start at a higher
-    # value it will yield an error.
-    num_zeros = num_classes - 1 - tf.cast(tf.squeeze(label), tf.int32)
-
-    zero_vec = tf.zeros(shape=(num_zeros), dtype=tf.int32)
-
-    levels = tf.concat([label_vec, zero_vec], axis=0)
-
-    return tf.cast(levels, tf.float32)
+    # This function uses tf.sequence_mask(), which is vectorized. Avoids map_fn()
+    # call.
+    return tf.sequence_mask(labels, maxlen=num_classes - 1, dtype=tf.float32)
 
 
 def _ordinal_loss_no_reduction(
@@ -37,7 +29,7 @@ def _ordinal_loss_no_reduction(
 
 
 # The outer function is a constructor to create a loss function using a certain number of classes.
-@tf.keras.utils.register_keras_serializable(package="coral_ordinal")
+# @tf.keras.utils.register_keras_serializable(package="coral_ordinal")
 class OrdinalCrossEntropy(tf.keras.losses.Loss):
     def __init__(
         self,
@@ -76,8 +68,7 @@ class OrdinalCrossEntropy(tf.keras.losses.Loss):
             self.num_classes = int(y_pred.get_shape().as_list()[1]) + 1
 
         # Convert each true label to a vector of ordinal level indicators.
-        fn = functools.partial(_label_to_levels, num_classes=self.num_classes)
-        tf_levels = tf.map_fn(fn, y_true)
+        tf_levels = _label_to_levels(tf.squeeze(y_true), self.num_classes)
 
         if self.importance_weights is None:
             importance_weights = tf.ones(self.num_classes - 1, dtype=tf.float32)

--- a/coral_ordinal/metrics.py
+++ b/coral_ordinal/metrics.py
@@ -16,8 +16,8 @@ class MeanAbsoluteErrorLabels(tf.keras.metrics.Metric):
         """Computes mean absolute error for ordinal labels.
 
         Args:
-          y_true: Cumulatiuve logits from CoralOrdinal layer.
-          y_pred: Labels.
+          y_true: Labels (int).
+          y_pred: Cumulative logits from CoralOrdinal layer.
           sample_weight (optional): Not implemented.
         """
 
@@ -32,7 +32,7 @@ class MeanAbsoluteErrorLabels(tf.keras.metrics.Metric):
 
         # Skip sigmoid and just operate on logit scale, since logit > 0 is
         # equivalent to prob > 0.5.
-        above_thresh = tf.map_fn(lambda x: tf.cast(x > 0.0, tf.float32), y_pred)
+        above_thresh = tf.cast(y_pred > 0.0, tf.float32)
 
         # Sum across columns to estimate how many cumulative thresholds are passed.
         labels_v2 = tf.reduce_sum(above_thresh, axis=1)
@@ -48,7 +48,7 @@ class MeanAbsoluteErrorLabels(tf.keras.metrics.Metric):
     def result(self):
         return tf.math.divide_no_nan(self.maes, self.count)
 
-    def reset_states(self):
+    def reset_state(self):
         """Resets all of the metric state variables at the start of each epoch."""
         K.batch_set_value([(v, 0) for v in self.variables])
 

--- a/coral_ordinal/version.py
+++ b/coral_ordinal/version.py
@@ -1,1 +1,1 @@
-__version__ = '0.1.7-dev'
+__version__ = "0.1.8-dev"


### PR DESCRIPTION
* replace calls to `tf.map_fn()` (slow) with vectorized TF operations (fast).  In particular, the label_to_levels() function can be vectorized using `tf.sequence_mask()`. Loss and metric calculations up to ~1000x speedup.

![coral_softmax_speedup](https://user-images.githubusercontent.com/48655643/155887623-2fd2c270-09cd-4160-a2c3-29c5c5c8f6bc.png)

![speedup_coral](https://user-images.githubusercontent.com/48655643/155887652-cc261e73-d063-48b5-b1a1-406ec79da2aa.png)



* makes https://github.com/ck37/coral-ordinal/issues/9 obsolete

* bump version to 0.1.8-dev