### PR TITLE
Implement sample_weight; fix serialization issue; add kernel/bias regularizer

### DIFF
--- a/coral_ordinal/layer.py
+++ b/coral_ordinal/layer.py
@@ -134,4 +134,5 @@ class CornOrdinal(tf.keras.layers.Dense):
     def get_config(self):
         config = super(CornOrdinal, self).get_config()
         config.update({"num_classes": self.num_classes, "activation": self.activation})
+        config.pop("units")
         return config

--- a/coral_ordinal/loss.py
+++ b/coral_ordinal/loss.py
@@ -117,7 +117,9 @@ class OrdinalCrossEntropy(tf.keras.losses.Loss):
             )
 
         if sample_weight is not None:
-            losses *= sample_weight
+            sample_weight = tf.cast(sample_weight, losses.dtype)
+            sample_weight = tf.broadcast_to(sample_weight, losses.shape)
+            losses = tf.multiply(losses, sample_weight)
 
         return _reduce_losses(losses, self.reduction)
 
@@ -194,5 +196,8 @@ class CornOrdinalCrossEntropy(tf.keras.losses.Loss):
         losses /= self.num_classes
 
         if sample_weight is not None:
-            losses *= sample_weight
+            sample_weight = tf.cast(sample_weight, losses.dtype)
+            sample_weight = tf.broadcast_to(sample_weight, losses.shape)
+            losses = tf.multiply(losses, sample_weight)
+
         return _reduce_losses(losses, self.reduction)

--- a/coral_ordinal/loss.py
+++ b/coral_ordinal/loss.py
@@ -47,7 +47,7 @@ def _reduce_losses(
 
 
 # The outer function is a constructor to create a loss function using a certain number of classes.
-# @tf.keras.utils.register_keras_serializable(package="coral_ordinal")
+@tf.keras.utils.register_keras_serializable(package="coral_ordinal")
 class OrdinalCrossEntropy(tf.keras.losses.Loss):
     """Computes ordinal cross entropy based on ordinal predictions and outcomes."""
 
@@ -131,7 +131,7 @@ class OrdinalCrossEntropy(tf.keras.losses.Loss):
         return {**base_config, **config}
 
 
-# @tf.keras.utils.register_keras_serializable(package="coral_ordinal")
+@tf.keras.utils.register_keras_serializable(package="coral_ordinal")
 class CornOrdinalCrossEntropy(tf.keras.losses.Loss):
     """Implements CORN ordinal loss function for logits."""
 

--- a/coral_ordinal/tests/test_layer.py
+++ b/coral_ordinal/tests/test_layer.py
@@ -1,0 +1,24 @@
+import tensorflow as tf
+import numpy as np
+import pytest
+
+from coral_ordinal import layer
+
+
+def _create_test_data():
+    # Test data from example in
+    # https://github.com/Raschka-research-group/coral-pytorch/blob/main/coral_pytorch/losses.py
+    np.random.seed(10)
+
+    X = np.random.normal(size=(8, 99))
+    y = np.array([0, 1, 2, 2, 2, 3, 4, 4])
+    return X, y
+
+
+def test_corn_layer():
+    corn_layer = layer.CornOrdinal(num_classes=4, kernel_initializer="uniform")
+    corn_layer_config = corn_layer.get_config()
+
+    corn_layer2 = layer.CornOrdinal(**corn_layer_config)
+
+    assert isinstance(corn_layer2, layer.CornOrdinal)

--- a/coral_ordinal/tests/test_loss.py
+++ b/coral_ordinal/tests/test_loss.py
@@ -91,3 +91,15 @@ def test_sample_weights_loss():
     ).numpy()
 
     np.testing.assert_allclose(loss_val * sample_weights, loss_val_weighted)
+
+
+def test_sample_weight_in_fit():
+    X, y, _ = _create_test_data()
+    w = np.zeros_like(y)
+    model = tf.keras.models.Sequential()
+    model.add(tf.keras.layers.Dense(5, input_dim=X.shape[1]))
+    model.add(layer.CornOrdinal(num_classes=4))
+    model.compile(loss=loss.OrdinalCrossEntropy())
+
+    history = model.fit(X, y, sample_weight=w, epochs=2)
+    np.testing.assert_allclose(np.array(history.history["loss"]), np.array([0.0, 0.0]))


### PR DESCRIPTION
* Allows to pass `sample_weight` to `.fit()` method and incorporate in loss functions (corn and coral) (related to / fixes https://github.com/ck37/coral-ordinal/issues/8)
* implement all reductions for corn/coral losses (requirement for sample weight)
* fix serialization issue with "units" in Corn layer (fixes https://github.com/ck37/coral-ordinal/issues/18)
* add bias/kernel regularizer to Coral (fixes https://github.com/ck37/coral-ordinal/issues/17)