### PR TITLE
update loss to work with sample weights

### DIFF
--- a/coral_ordinal/loss.py
+++ b/coral_ordinal/loss.py
@@ -18,6 +18,8 @@ def _coral_ordinal_loss_no_reduction(
     logits: tf.Tensor, levels: tf.Tensor, importance: tf.Tensor
 ) -> tf.Tensor:
     """Compute ordinal loss without reduction."""
+    levels = tf.cast(levels, dtype=logits.dtype)
+    importance = tf.cast(importance, dtype=logits.dtype)
     losses = -tf.reduce_sum(
         (
             tf.math.log_sigmoid(logits) * levels
@@ -179,8 +181,6 @@ class CornOrdinalCrossEntropy(tf.keras.losses.Loss):
             set_mask, label_gt_i = s
             n_examples_task = tf.reduce_sum(tf.cast(set_mask, dtype=tf.float32))
             n_examples.append(n_examples_task)
-            if tf.keras.backend.equal(n_examples_task, 0.0):
-                continue
 
             pred_task = tf.gather(y_pred, task_index, axis=1)
             losses_task = tf.where(


### PR DESCRIPTION
* remove the switch for number of examples per batch that satisfy the y > i set condition.  This is required to a) not have tensorflow complain about using a Tensor in if statement; b) the dimensions of sample weights don't match anymore if the for loop includes that switch.  In order for losses and sample_weights (And any other function that expected losses.shape[0] == batch_size) the if swithc must be removed)