### PR TITLE
Remove if switch in loss calculation to guarantee losses.shape[0] is always batch_size (and matches sample weight)

### DIFF
--- a/coral_ordinal/loss.py
+++ b/coral_ordinal/loss.py
@@ -18,6 +18,8 @@ def _coral_ordinal_loss_no_reduction(
     logits: tf.Tensor, levels: tf.Tensor, importance: tf.Tensor
 ) -> tf.Tensor:
     """Compute ordinal loss without reduction."""
+    levels = tf.cast(levels, dtype=logits.dtype)
+    importance = tf.cast(importance, dtype=logits.dtype)
     losses = -tf.reduce_sum(
         (
             tf.math.log_sigmoid(logits) * levels
@@ -179,8 +181,6 @@ class CornOrdinalCrossEntropy(tf.keras.losses.Loss):
             set_mask, label_gt_i = s
             n_examples_task = tf.reduce_sum(tf.cast(set_mask, dtype=tf.float32))
             n_examples.append(n_examples_task)
-            if tf.keras.backend.equal(n_examples_task, 0.0):
-                continue
 
             pred_task = tf.gather(y_pred, task_index, axis=1)
             losses_task = tf.where(

--- a/coral_ordinal/loss.py
+++ b/coral_ordinal/loss.py
@@ -174,12 +174,9 @@ class CornOrdinalCrossEntropy(tf.keras.losses.Loss):
             label_gt_i = y_true > i
             sets.append((set_mask, label_gt_i))
 
-        n_examples = []
         losses = tf.zeros_like(y_true)
         for task_index, s in enumerate(sets):
             set_mask, label_gt_i = s
-            n_examples_task = tf.reduce_sum(tf.cast(set_mask, dtype=tf.float32))
-            n_examples.append(n_examples_task)
 
             pred_task = tf.gather(y_pred, task_index, axis=1)
             losses_task = tf.where(

--- a/coral_ordinal/loss.py
+++ b/coral_ordinal/loss.py
@@ -120,7 +120,6 @@ class OrdinalCrossEntropy(tf.keras.losses.Loss):
 
         if sample_weight is not None:
             sample_weight = tf.cast(sample_weight, losses.dtype)
-            sample_weight = tf.broadcast_to(sample_weight, losses.shape)
             losses = tf.multiply(losses, sample_weight)
 
         return _reduce_losses(losses, self.reduction)
@@ -197,7 +196,6 @@ class CornOrdinalCrossEntropy(tf.keras.losses.Loss):
 
         if sample_weight is not None:
             sample_weight = tf.cast(sample_weight, losses.dtype)
-            sample_weight = tf.broadcast_to(sample_weight, losses.shape)
             losses = tf.multiply(losses, sample_weight)
 
         return _reduce_losses(losses, self.reduction)

--- a/coral_ordinal/tests/test_loss.py
+++ b/coral_ordinal/tests/test_loss.py
@@ -107,7 +107,7 @@ def test_sample_weight_in_fit():
     model = tf.keras.models.Sequential()
     model.add(tf.keras.layers.Dense(5, input_dim=X.shape[1]))
     model.add(layer.CornOrdinal(num_classes=4))
-    model.compile(loss=loss.OrdinalCrossEntropy())
+    model.compile(loss=loss.CornOrdinalCrossEntropy())
 
     history = model.fit(X, y, sample_weight=w, epochs=2)
     np.testing.assert_allclose(np.array(history.history["loss"]), np.array([0.0, 0.0]))
@@ -118,7 +118,7 @@ def test_class_weight_in_fit():
     model = tf.keras.models.Sequential()
     model.add(tf.keras.layers.Dense(5, input_dim=X.shape[1]))
     model.add(layer.CornOrdinal(num_classes=4))
-    model.compile(loss=loss.OrdinalCrossEntropy())
+    model.compile(loss=loss.CornOrdinalCrossEntropy())
 
     history = model.fit(
         X, y, epochs=2, class_weight={0: 0.0, 1: 0.0, 2: 0.0, 3: 0.0, 4: 0.0}

--- a/coral_ordinal/tests/test_loss.py
+++ b/coral_ordinal/tests/test_loss.py
@@ -106,7 +106,7 @@ def test_sample_weight_in_fit():
     w = np.zeros_like(y)
     model = tf.keras.models.Sequential()
     model.add(tf.keras.layers.Dense(5, input_dim=X.shape[1]))
-    model.add(layer.CornOrdinal(num_classes=4))
+    model.add(layer.CornOrdinal(num_classes=len(np.unique(y))))
     model.compile(loss=loss.CornOrdinalCrossEntropy())
 
     history = model.fit(X, y, sample_weight=w, epochs=2)
@@ -117,7 +117,7 @@ def test_class_weight_in_fit():
     X, y, _ = _create_test_data()
     model = tf.keras.models.Sequential()
     model.add(tf.keras.layers.Dense(5, input_dim=X.shape[1]))
-    model.add(layer.CornOrdinal(num_classes=4))
+    model.add(layer.CornOrdinal(num_classes=len(np.unique(y))))
     model.compile(loss=loss.CornOrdinalCrossEntropy())
 
     history = model.fit(


### PR DESCRIPTION
* remove the switch for number of examples per batch that satisfy the y > i set condition.  This is required to a) not have tensorflow complain about using a Tensor in if statement; b) the dimensions of sample weights don't match anymore if the for loop includes that switch.  In order for losses and sample_weights (And any other function that expected losses.shape[0] == batch_size) the if swithc must be removed)
* also allows for `class_weight` to be passed (unit test)
* remove `.shape` in broadcast to avoid None shape in loss batch calculation